### PR TITLE
Rename job

### DIFF
--- a/jobs/suse-ruby-buildpack/spec
+++ b/jobs/suse-ruby-buildpack/spec
@@ -1,5 +1,5 @@
 ---
-name: ruby-buildpack
+name: suse-ruby-buildpack
 templates: {}
 
 packages:


### PR DESCRIPTION
having a different job name than the upstream buildpacks makes it easier
for the kubecf ops files to setup buildpacks.